### PR TITLE
Add missing margin in detail display

### DIFF
--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ComparisonScreen.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ComparisonScreen.java
@@ -59,6 +59,9 @@ public class ComparisonScreen extends DialogFragment {
     public static final String DEBUG_TAG = "ComparisonScreen";
     public static final String versionA = "A";
     public static final String versionB = "B";
+    public static final String DATA_A_KEY = "DataA";
+    public static final String DATA_B_KEY = "DataB";
+    public static final String BASE_URL_KEY = "baseUrl";
 
     LinearLayout llA;
     LinearLayout llB;
@@ -67,15 +70,17 @@ public class ComparisonScreen extends DialogFragment {
     ProgressBar progressBar;
     OsmElement elementA, elementB;
     Changeset resultA = null, resultB = null;
+    String baseUrl;
 
     public ComparisonScreen() {
     }
 
-    public static ComparisonScreen newInstance(OsmElement elementA, OsmElement elementB) {
+    public static ComparisonScreen newInstance(String baseUrl, OsmElement elementA, OsmElement elementB) {
         ComparisonScreen cs = new ComparisonScreen();
         Bundle args = new Bundle();
-        args.putSerializable("DataA", elementA);
-        args.putSerializable("DataB", elementB);
+        args.putString(BASE_URL_KEY, baseUrl);
+        args.putSerializable(DATA_A_KEY, elementA);
+        args.putSerializable(DATA_B_KEY, elementB);
         cs.setArguments(args);
         return cs;
     }
@@ -84,9 +89,9 @@ public class ComparisonScreen extends DialogFragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Bundle args = getArguments();
-
-        elementA = (OsmElement) args.getSerializable("DataA");
-        elementB = (OsmElement) args.getSerializable("DataB");
+        baseUrl = args.getString(BASE_URL_KEY);
+        elementA = (OsmElement) args.getSerializable(DATA_A_KEY);
+        elementB = (OsmElement) args.getSerializable(DATA_B_KEY);
     }
 
     @Override
@@ -404,7 +409,7 @@ public class ComparisonScreen extends DialogFragment {
      * on the background thread and post the result back on the main thread
      */
     void fetchChangeset(long csId, String version) {
-        URL url = getChangeSetUrl(csId);
+        URL url = getChangeSetUrl(baseUrl, csId);
         try {
             new AsyncTask<Void, Void, Boolean>() {
 

--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ElementHistoryDialog.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ElementHistoryDialog.java
@@ -49,6 +49,7 @@ public class ElementHistoryDialog extends DialogFragment {
     LinearLayout parentLayout;
     LinearLayout errorLayout;
     Button goBackBtn;
+    String baseUrl;
 
     private static final String DEBUG_TAG = "ElementHistoryDialog";
 
@@ -60,12 +61,25 @@ public class ElementHistoryDialog extends DialogFragment {
      * @return instance of the Dialog
      */
     public static ElementHistoryDialog create(long osmId, String elementType) {
-        return new ElementHistoryDialog(osmId, elementType);
+        return new ElementHistoryDialog(Util.BASE_URL, osmId, elementType);
+    }
+    
+    /**
+     * Method that will create a new instance of the Dialog
+     *
+     * @param baseUrl     base API url to use
+     * @param osmId       the id of the OSM element to be displayed
+     * @param elementType the OSM element type
+     * @return instance of the Dialog
+     */
+    public static ElementHistoryDialog create(String baseUrl, long osmId, String elementType) {
+        return new ElementHistoryDialog(baseUrl, osmId, elementType);
     }
 
-    private ElementHistoryDialog(long osmId, String elementType) {
+    private ElementHistoryDialog(String baseUrl, long osmId, String elementType) {
         this.osmId = osmId;
         this.elementType = elementType;
+        this.baseUrl = baseUrl;
         osmParser = new OsmParser();
     }
 
@@ -109,7 +123,7 @@ public class ElementHistoryDialog extends DialogFragment {
                 //navigate to comparison screen
                 OsmElement elementA = osmParser.getStorage().getAll().get(positionA);
                 OsmElement elementB = osmParser.getStorage().getAll().get(positionB);
-                ComparisonScreen cs = ComparisonScreen.newInstance(elementA, elementB);
+                ComparisonScreen cs = ComparisonScreen.newInstance(baseUrl, elementA, elementB);
 
                 if (getFragmentManager() != null) {
                     getFragmentManager().beginTransaction()
@@ -200,7 +214,7 @@ public class ElementHistoryDialog extends DialogFragment {
      * on the background thread and post the result back on the main thread
      */
     void fetchHistoryData() {
-        URL url = Util.getElementHistoryUrl(osmId, elementType);
+        URL url = Util.getElementHistoryUrl(baseUrl, osmId, elementType);
         try {
             new AsyncTask<Void, Void, Boolean>() {
 

--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ElementHistoryDialog.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ElementHistoryDialog.java
@@ -104,7 +104,7 @@ public class ElementHistoryDialog extends DialogFragment {
 
         c.setOnClickListener(v -> {
             if (positionA == -1 || positionB == -1) {
-                Toast.makeText(requireContext(), "Select version A & B for comparison", Toast.LENGTH_SHORT).show();
+                Toast.makeText(requireContext(), R.string.select_a_b_toast, Toast.LENGTH_SHORT).show();
             } else {
                 //navigate to comparison screen
                 OsmElement elementA = osmParser.getStorage().getAll().get(positionA);

--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
@@ -22,20 +22,21 @@ import okhttp3.Response;
 
 public class Util {
 
-    public static final String BASE_HISTORY_URL = "https://api.openstreetmap.org/api/0.6/";
+    public static final String BASE_URL = "https://api.openstreetmap.org/api/0.6/";
     public static final String DEBUG_TAG = "utility-method";
 
     /**
      * Utility URL building function for a given OSM element
      *
+     * @param baseUrl base url for the API
      * @param osmId       id of the current OSM element
      * @param elementType type of the current OSM element
      * @return URL to fetch the history data
      */
-    public static URL getElementHistoryUrl(long osmId, String elementType) {
+    public static URL getElementHistoryUrl(String baseUrl, long osmId, String elementType) {
         URL url = null;
         try {
-            url = new URL(BASE_HISTORY_URL + elementType + "/" + osmId + "/history");
+            url = new URL(baseUrl + elementType + "/" + osmId + "/history");
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }
@@ -45,13 +46,14 @@ public class Util {
     /**
      * Utility URL building function for a given changeset
      *
+     * @param baseUrl base url for the API
      * @param osmId id of the current OSM element
      * @return URL to fetch the changeset
      */
-    public static URL getChangeSetUrl(long osmId) {
+    public static URL getChangeSetUrl(String baseUrl, long osmId) {
         URL url = null;
         try {
-            url = new URL(BASE_HISTORY_URL + "changeset/" + osmId);
+            url = new URL(baseUrl + "changeset/" + osmId);
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }

--- a/ElementHistoryDialog/src/main/res/layout/element_details.xml
+++ b/ElementHistoryDialog/src/main/res/layout/element_details.xml
@@ -30,13 +30,14 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_marginLeft="4dp"
-            android:layout_marginRight="4dp"
             android:text="@string/created_on" />
 
         <TextView
             android:id="@+id/date_created"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginLeft="4dp"
             tools:text="11/1/12 23:12:32" />
 
     </LinearLayout>

--- a/ElementHistoryDialog/src/main/res/values/strings.xml
+++ b/ElementHistoryDialog/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="nodes_text">NODES</string>
     <string name="go_back">Go Back</string>
     <string name="selected_element_deleted">The Selected element has been deleted</string>
+    <string name="select_a_b_toast">Select version A &amp; B for comparison</string>
 </resources>


### PR DESCRIPTION
Hi, I'm in the process of integrating the dialog with Vespucci. The detail display is missing a margin before the date, and the base Url needs to be configurable added in this PR.

The other issue is that the release on jipack.io seems to be out of sync with the code here, for example the text of the exit button is different, probably a good idea to bump the version and release a patch release in any case.