### PR TITLE
Use baseUrl when restarting dialog, not the default

### DIFF
--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ComparisonScreen.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/ComparisonScreen.java
@@ -143,7 +143,7 @@ public class ComparisonScreen extends DialogFragment {
                 getDialog().onBackPressed();
                 if (getFragmentManager() != null) {
                     getFragmentManager().beginTransaction()
-                            .add(ElementHistoryDialog.create(elementA.osmId, elementA.getType().name().toLowerCase()), null)
+                            .add(ElementHistoryDialog.create(baseUrl, elementA.osmId, elementA.getType().name().toLowerCase()), null)
                             .hide(this)
                             .commit();
                 }


### PR DESCRIPTION
I missed one location where the dialog was using the default API url yesterday. 

In principal you wouldn't have to dismiss the version selection dialog and then you wouldn't have to re-create it when going back from the comparison screen, but with this change it works as is.