### PR TITLE
getContext will return null in some situations

### DIFF
--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
@@ -152,7 +152,11 @@ public class Util {
      * @param textView the TextView
      * @param ex the Exception
      */
-    public static void displayException(@NonNull Context ctx, @NonNull TextView textView, @NonNull Exception ex) {
+    public static void displayException(@Nullable Context ctx, @NonNull TextView textView, @NonNull Exception ex) {
+        if (ctx == null) {
+            Log(DEBUG_TAG, "displayException null Context");
+            return;
+        }
         if (ex != null) {
             String message = ex.getLocalizedMessage();
             if (ex instanceof OsmApiException) {


### PR DESCRIPTION
getContext can return null if the fragment is (no longer) attached, this protects against crashing when trying to display an exception (which potentially was the cause of no longer being attached).