### PR TITLE
Fix typo

### DIFF
--- a/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
+++ b/ElementHistoryDialog/src/main/java/me/zed/elementhistorydialog/Util.java
@@ -154,7 +154,7 @@ public class Util {
      */
     public static void displayException(@Nullable Context ctx, @NonNull TextView textView, @NonNull Exception ex) {
         if (ctx == null) {
-            Log(DEBUG_TAG, "displayException null Context");
+            Log.d(DEBUG_TAG, "displayException null Context");
             return;
         }
         if (ex != null) {


### PR DESCRIPTION
Fix typo that stopped compilation

Note that lint fails unrelated to this change, which might or might not cause an issue with jitpack